### PR TITLE
Fix: relative imports for internal modules

### DIFF
--- a/sreeg/interface.py
+++ b/sreeg/interface.py
@@ -411,7 +411,7 @@ def activity_brain(activity, montage=None, when=None, reducer="mean",
     import numpy as np
     import matplotlib.pyplot as plt
     from sreeg.electrodes import get_electrode_positions
-    from equipotential import plot_equipotential_map
+    from .equipotential import plot_equipotential_map
 
     # --- Resolve metadata ---
     if isinstance(activity, dict) and "activity" in activity:
@@ -531,7 +531,7 @@ def activity_to_dipole(activity,
 
     # --- Local imports to avoid circular dependencies ---
     from sreeg.interface import activity_brain
-    from onedipoleprediction import (
+    from .onedipoleprediction import (
         dipole_orientation_by_nodal_plane,
         dipole_position_by_planes,
         dipole_orientation_by_fast_grid,

--- a/sreeg/onedipoleprediction.py
+++ b/sreeg/onedipoleprediction.py
@@ -1,5 +1,5 @@
 import numpy as np
-from equipotential import equipotentials
+from .equipotential import equipotentials
 from scipy.spatial import cKDTree
 from scipy.optimize import minimize
 from sreeg.electrodes import evaluate_dipole_at_electrodes


### PR DESCRIPTION
Implements relative imports for internal modules equipotential and onedipoleprediction to ensure proper package resolution.
Verified that the official README example executes successfully after this fix.